### PR TITLE
Add movie posters

### DIFF
--- a/CineCompass.xcodeproj/project.pbxproj
+++ b/CineCompass.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0859469029F7E36500B803CF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0859468F29F7E36500B803CF /* Constants.swift */; };
 		0859469329F7EA6100B803CF /* MovieCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0859469129F7EA6100B803CF /* MovieCell.swift */; };
 		0859469429F7EA6100B803CF /* MovieCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0859469229F7EA6100B803CF /* MovieCell.xib */; };
+		0888EABE29FA4CA400F6FAF3 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0888EABD29FA4CA400F6FAF3 /* Kingfisher */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0888EABE29FA4CA400F6FAF3 /* Kingfisher in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -191,6 +193,9 @@
 			dependencies = (
 			);
 			name = CineCompass;
+			packageProductDependencies = (
+				0888EABD29FA4CA400F6FAF3 /* Kingfisher */,
+			);
 			productName = CineCompass;
 			productReference = 0815C29D29EF6A340052E5D2 /* CineCompass.app */;
 			productType = "com.apple.product-type.application";
@@ -263,6 +268,9 @@
 				Base,
 			);
 			mainGroup = 0815C29429EF6A340052E5D2;
+			packageReferences = (
+				0888EABC29FA4CA400F6FAF3 /* XCRemoteSwiftPackageReference "Kingfisher" */,
+			);
 			productRefGroup = 0815C29E29EF6A340052E5D2 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -652,6 +660,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		0888EABC29FA4CA400F6FAF3 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0888EABD29FA4CA400F6FAF3 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0888EABC29FA4CA400F6FAF3 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 0815C29529EF6A340052E5D2 /* Project object */;
 }

--- a/CineCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CineCompass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher",
+      "state" : {
+        "revision" : "af4be924ad984cf4d16f4ae4df424e79a443d435",
+        "version" : "7.6.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/CineCompass/Constants.swift
+++ b/CineCompass/Constants.swift
@@ -10,4 +10,8 @@ struct K {
     static let detailSegue = "GoToMovieDetails"
     static let cellIdentifier = "ReusableCell"
     static let cellNibName = "MovieCell"
+    static let searchURL = "https://api.themoviedb.org/3/search/movie"
+    static let detailsURL = "https://api.themoviedb.org/3/movie"
+    static let apiKey = "87027965472f4df58ab7f4cfb6212185"
+    static let posterImageBaseUrl = "https://image.tmdb.org/t/p/w500/"
 }

--- a/CineCompass/Controller/MovieDetailsViewController.swift
+++ b/CineCompass/Controller/MovieDetailsViewController.swift
@@ -32,9 +32,8 @@ class MovieDetailsViewController: UIViewController {
         }
         movieOverview.text = movieDetails?.overview
         
-        let baseURL = K.posterImageBaseUrl
         if let posterPath = movieDetails?.posterPath {
-            let posterURL = URL(string: baseURL + posterPath)
+            let posterURL = URL(string: K.posterImageBaseUrl + posterPath)
             moviePoster.kf.setImage(with: posterURL)
         }
     }

--- a/CineCompass/Controller/MovieDetailsViewController.swift
+++ b/CineCompass/Controller/MovieDetailsViewController.swift
@@ -23,10 +23,10 @@ class MovieDetailsViewController: UIViewController {
         movieGenres.text = (movieDetails?.genres[0].name ?? " ") + "   " + (movieDetails?.genres[1].name ?? " ") + "   " + (movieDetails?.genres[2].name ?? " ")
         movieOverview.text = movieDetails?.overview
         
-//        let baseURL = "https://image.tmdb.org/t/p/w500/"
-//        if let posterPath = movieDetails?.posterPath {
-//            let posterURL = URL(string: baseURL + posterPath)
-//            moviePoster.kf.setImage(with: posterURL)
-//        }
+        let baseURL = "https://image.tmdb.org/t/p/w500/"
+        if let posterPath = movieDetails?.posterPath {
+            let posterURL = URL(string: baseURL + posterPath)
+            moviePoster.kf.setImage(with: posterURL)
+        }
     }
 }

--- a/CineCompass/Controller/MovieDetailsViewController.swift
+++ b/CineCompass/Controller/MovieDetailsViewController.swift
@@ -22,5 +22,11 @@ class MovieDetailsViewController: UIViewController {
         movieVoteAvg.text = String(format: "%.1f", movieDetails?.voteAverage ?? -9999.9999)
         movieGenres.text = (movieDetails?.genres[0].name ?? " ") + "   " + (movieDetails?.genres[1].name ?? " ") + "   " + (movieDetails?.genres[2].name ?? " ")
         movieOverview.text = movieDetails?.overview
+        
+//        let baseURL = "https://image.tmdb.org/t/p/w500/"
+//        if let posterPath = movieDetails?.posterPath {
+//            let posterURL = URL(string: baseURL + posterPath)
+//            moviePoster.kf.setImage(with: posterURL)
+//        }
     }
 }

--- a/CineCompass/Controller/MovieDetailsViewController.swift
+++ b/CineCompass/Controller/MovieDetailsViewController.swift
@@ -20,7 +20,16 @@ class MovieDetailsViewController: UIViewController {
         movieTitle.text = movieDetails?.title
         movieReleaseDate.text = movieDetails?.releaseDate
         movieVoteAvg.text = String(format: "%.1f", movieDetails?.voteAverage ?? -9999.9999)
-        movieGenres.text = (movieDetails?.genres[0].name ?? " ") + "   " + (movieDetails?.genres[1].name ?? " ") + "   " + (movieDetails?.genres[2].name ?? " ")
+        if let genres = movieDetails?.genres {
+            var genreNames: [String] = []
+            for genre in genres {
+                genreNames.append(genre.name)
+            }
+            movieGenres.text = genreNames.joined(separator: ", ")
+        }
+        else {
+            movieGenres.text = " No genres defined"
+        }
         movieOverview.text = movieDetails?.overview
         
         let baseURL = "https://image.tmdb.org/t/p/w500/"

--- a/CineCompass/Controller/MovieDetailsViewController.swift
+++ b/CineCompass/Controller/MovieDetailsViewController.swift
@@ -32,7 +32,7 @@ class MovieDetailsViewController: UIViewController {
         }
         movieOverview.text = movieDetails?.overview
         
-        let baseURL = "https://image.tmdb.org/t/p/w500/"
+        let baseURL = K.posterImageBaseUrl
         if let posterPath = movieDetails?.posterPath {
             let posterURL = URL(string: baseURL + posterPath)
             moviePoster.kf.setImage(with: posterURL)

--- a/CineCompass/Controller/SearchResultsViewController.swift
+++ b/CineCompass/Controller/SearchResultsViewController.swift
@@ -49,9 +49,8 @@ extension SearchResultsViewController: UITableViewDataSource, UITableViewDelegat
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: K.cellIdentifier, for: indexPath) as! MovieCell
         cell.movieName.text = movies[indexPath.row].title
-        let baseURL = K.posterImageBaseUrl
         if let posterPath = movies[indexPath.row].posterPath {
-            let posterURL = URL(string: baseURL + posterPath)
+            let posterURL = URL(string: K.posterImageBaseUrl + posterPath)
             cell.moviePoster.kf.setImage(with: posterURL)
         }
         return cell

--- a/CineCompass/Controller/SearchResultsViewController.swift
+++ b/CineCompass/Controller/SearchResultsViewController.swift
@@ -49,7 +49,7 @@ extension SearchResultsViewController: UITableViewDataSource, UITableViewDelegat
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: K.cellIdentifier, for: indexPath) as! MovieCell
         cell.movieName.text = movies[indexPath.row].title
-        let baseURL = "https://image.tmdb.org/t/p/w500/"
+        let baseURL = K.posterImageBaseUrl
         if let posterPath = movies[indexPath.row].posterPath {
             let posterURL = URL(string: baseURL + posterPath)
             cell.moviePoster.kf.setImage(with: posterURL)

--- a/CineCompass/Controller/SearchResultsViewController.swift
+++ b/CineCompass/Controller/SearchResultsViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 class SearchResultsViewController: UIViewController {
     
@@ -48,6 +49,11 @@ extension SearchResultsViewController: UITableViewDataSource, UITableViewDelegat
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: K.cellIdentifier, for: indexPath) as! MovieCell
         cell.movieName.text = movies[indexPath.row].title
+        let baseURL = "https://image.tmdb.org/t/p/w500/"
+        if let posterPath = movies[indexPath.row].posterPath {
+            let posterURL = URL(string: baseURL + posterPath)
+            cell.moviePoster.kf.setImage(with: posterURL)
+        }
         return cell
     }
     

--- a/CineCompass/Model/MovieData.swift
+++ b/CineCompass/Model/MovieData.swift
@@ -13,4 +13,10 @@ struct MovieData: Codable {
 struct Movie: Codable {
     let id: Int
     let title: String
+    let posterPath: String?
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case posterPath = "poster_path"
+    }
 }

--- a/CineCompass/Model/MovieManager.swift
+++ b/CineCompass/Model/MovieManager.swift
@@ -15,64 +15,32 @@ protocol MovieManagerDetailsDelegate: AnyObject {
 }
 
 final class MovieManager {
-
+    
     weak var delegate: MovieManagerDelegate?
     weak var detailsDelegate: MovieManagerDetailsDelegate?
+    private let session = URLSession(configuration: .default)
+    
     func searchMovies(movieName: String) {
         let encodedMovieName = movieName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         let urlString = "\(K.searchURL)?api_key=\(K.apiKey)&query=\(encodedMovieName)"
-        // create url
-        guard let url = URL(string: urlString) else {
-            print("Invalid URL")
-            return
-        }
-//        print("URL: \(url)")
-        // create urlsession
-        let session = URLSession(configuration: .default)
-        // create url session a task
-        let task = session.dataTask(with: url) { [weak self] data, response, error in
-            if let error = error {
-                print(error)
-            }
-            guard let data = data else {
-                print("No data received")
-                return
-            }
-//            print("ReceivedData: \(String(data: data, encoding: .utf8) ?? "No Data")")
-            if let movies = self?.parseMovieData(data) {
-                self?.delegate?.didReceiveMovies(movies)
+        fetchData(urlString: urlString) { data in
+            if let movies = self.parseMovieData(data) {
+                self.delegate?.didReceiveMovies(movies)
             }
         }
-        // start the task
-        task.resume()
     }
     
     func getMovieDetails(using movieID: Int) {
         let urlString = "\(K.detailsURL)/\(movieID)?api_key=\(K.apiKey)"
-        guard let url = URL(string: urlString) else {
-            print("Invalid URL")
-            return
-        }
-        // create urlsession
-        let session = URLSession(configuration: .default)
-        // create url session a task
-        let task = session.dataTask(with: url) { [weak self] data, response, error in
-            if let error = error {
-                print(error)
-            }
-            guard let data = data else {
-                print("no data received")
-                return
-            }
-            if let movieDetails = self?.parseMovieDetailsData(data) {
-                self?.detailsDelegate?.didReceiveMovieDetails(movieDetails)
+        fetchData(urlString: urlString) { data in
+            if let movieDetails = self.parseMovieDetailsData(data) {
+                self.detailsDelegate?.didReceiveMovieDetails(movieDetails)
             }
         }
-        task.resume()
     }
     
     
-    func parseMovieData(_ data: Data) -> [Movie]? {
+    private func parseMovieData(_ data: Data) -> [Movie]? {
         let decoder = JSONDecoder()
         do {
             let decodedData = try decoder.decode(MovieData.self, from: data)
@@ -83,15 +51,33 @@ final class MovieManager {
         }
     }
     
-    func parseMovieDetailsData(_ data: Data) -> MovieDetailsDataResponse? {
+    private func parseMovieDetailsData(_ data: Data) -> MovieDetailsDataResponse? {
         let decoder = JSONDecoder()
         do {
             let decodedData = try decoder.decode(MovieDetailsDataResponse.self, from: data)
-//            print("Parsed movies: \(decodedData.results)")
             return decodedData
         } catch {
             print("error decoding JSON")
             return nil
         }
+    }
+    
+    private func fetchData(urlString: String, completion: @escaping (Data) -> Void) {
+        guard let url = URL(string: urlString) else {
+            print("Invalid URL")
+            return
+        }
+        let task = session.dataTask(with: url) { [weak self] data, response, error in
+            guard self != nil else {return}
+            if let error = error {
+                print(error)
+            }
+            guard let data = data else {
+                print("no data received")
+                return
+            }
+            completion(data)
+        }
+        task.resume()
     }
 }

--- a/CineCompass/Model/MovieManager.swift
+++ b/CineCompass/Model/MovieManager.swift
@@ -15,14 +15,12 @@ protocol MovieManagerDetailsDelegate: AnyObject {
 }
 
 final class MovieManager {
-    let searchURL = "https://api.themoviedb.org/3/search/movie"
-    let detailsURL = "https://api.themoviedb.org/3/movie"
-    let apiKey = "87027965472f4df58ab7f4cfb6212185"
+
     weak var delegate: MovieManagerDelegate?
     weak var detailsDelegate: MovieManagerDetailsDelegate?
     func searchMovies(movieName: String) {
         let encodedMovieName = movieName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        let urlString = "\(searchURL)?api_key=\(apiKey)&query=\(encodedMovieName)"
+        let urlString = "\(K.searchURL)?api_key=\(K.apiKey)&query=\(encodedMovieName)"
         // create url
         guard let url = URL(string: urlString) else {
             print("Invalid URL")
@@ -50,7 +48,7 @@ final class MovieManager {
     }
     
     func getMovieDetails(using movieID: Int) {
-        let urlString = "\(detailsURL)/\(movieID)?api_key=\(apiKey)"
+        let urlString = "\(K.detailsURL)/\(movieID)?api_key=\(K.apiKey)"
         guard let url = URL(string: urlString) else {
             print("Invalid URL")
             return

--- a/CineCompass/View/Base.lproj/Main.storyboard
+++ b/CineCompass/View/Base.lproj/Main.storyboard
@@ -147,7 +147,11 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SId-Kk-ihu">
-                                <rect key="frame" x="50" y="116" width="293" height="319"/>
+                                <rect key="frame" x="96.666666666666686" y="56" width="200" height="300"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="200" id="3QY-v7-v4D"/>
+                                    <constraint firstAttribute="height" constant="300" id="lnp-fM-EBn"/>
+                                </constraints>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="KGm-3p-hnN"/>
@@ -155,21 +159,19 @@
                         <constraints>
                             <constraint firstItem="7qk-KD-ywo" firstAttribute="leading" secondItem="KGm-3p-hnN" secondAttribute="leading" constant="5" id="BGl-cN-1Go"/>
                             <constraint firstItem="vYD-mb-wpl" firstAttribute="top" secondItem="ZIm-1w-vth" secondAttribute="bottom" constant="8" id="DOW-MT-OJu"/>
+                            <constraint firstItem="SId-Kk-ihu" firstAttribute="top" secondItem="KGm-3p-hnN" secondAttribute="top" id="GXE-9j-HUB"/>
                             <constraint firstItem="7qk-KD-ywo" firstAttribute="top" secondItem="P8z-9c-PKr" secondAttribute="bottom" constant="8" id="Gdt-PB-grQ"/>
-                            <constraint firstItem="SId-Kk-ihu" firstAttribute="leading" secondItem="KGm-3p-hnN" secondAttribute="leading" constant="50" id="HyR-nZ-ISV"/>
                             <constraint firstItem="ZIm-1w-vth" firstAttribute="top" secondItem="dCe-N7-ryW" secondAttribute="bottom" constant="10" id="L3y-Jn-1cZ"/>
                             <constraint firstItem="KGm-3p-hnN" firstAttribute="trailing" secondItem="P8z-9c-PKr" secondAttribute="trailing" constant="5" id="NCr-H7-7lT"/>
-                            <constraint firstItem="dCe-N7-ryW" firstAttribute="top" secondItem="SId-Kk-ihu" secondAttribute="bottom" constant="10" id="NSl-le-NJn"/>
                             <constraint firstItem="dCe-N7-ryW" firstAttribute="leading" secondItem="KGm-3p-hnN" secondAttribute="leading" constant="5" id="QT3-qg-BDr"/>
                             <constraint firstItem="KGm-3p-hnN" firstAttribute="trailing" secondItem="ZIm-1w-vth" secondAttribute="trailing" constant="5" id="SFV-YI-8Ff"/>
-                            <constraint firstItem="SId-Kk-ihu" firstAttribute="top" secondItem="KGm-3p-hnN" secondAttribute="top" constant="60" id="Wl0-Hz-Rwc"/>
                             <constraint firstItem="vYD-mb-wpl" firstAttribute="leading" secondItem="KGm-3p-hnN" secondAttribute="leading" constant="5" id="ZOE-oM-2vV"/>
                             <constraint firstItem="KGm-3p-hnN" firstAttribute="trailing" secondItem="7qk-KD-ywo" secondAttribute="trailing" constant="5" id="ano-p3-XgR"/>
                             <constraint firstItem="P8z-9c-PKr" firstAttribute="top" secondItem="vYD-mb-wpl" secondAttribute="bottom" constant="8" id="bNI-4d-Uea"/>
+                            <constraint firstItem="SId-Kk-ihu" firstAttribute="centerX" secondItem="aLy-lf-1TV" secondAttribute="centerX" id="ev4-Om-2ks"/>
                             <constraint firstItem="7qk-KD-ywo" firstAttribute="bottom" secondItem="KGm-3p-hnN" secondAttribute="bottom" constant="-30" id="f2e-qe-S4s"/>
                             <constraint firstItem="KGm-3p-hnN" firstAttribute="trailing" secondItem="vYD-mb-wpl" secondAttribute="trailing" constant="5" id="gQk-1d-KJZ"/>
                             <constraint firstItem="KGm-3p-hnN" firstAttribute="trailing" secondItem="dCe-N7-ryW" secondAttribute="trailing" constant="5" id="jdk-lf-Yhh"/>
-                            <constraint firstItem="KGm-3p-hnN" firstAttribute="trailing" secondItem="SId-Kk-ihu" secondAttribute="trailing" constant="50" id="mPD-pB-gNn"/>
                             <constraint firstItem="ZIm-1w-vth" firstAttribute="leading" secondItem="KGm-3p-hnN" secondAttribute="leading" constant="5" id="o5X-SP-zvQ"/>
                             <constraint firstItem="P8z-9c-PKr" firstAttribute="leading" secondItem="KGm-3p-hnN" secondAttribute="leading" constant="5" id="xwo-aV-RYp"/>
                         </constraints>


### PR DESCRIPTION
Enhancements for Movie Details and Search Results

In this pull request, several significant improvements were made about movie details and search results functionality.

Kingfisher Integration: Integrated the Kingfisher library into the project. This library simplifies the process of downloading and caching images from the web, which has been used to fetch and display movie posters in both the Search Results and Movie Details views.

UI Improvements: Adjustments are made to the Movie Details view to ensure that all relevant information (title, genres, release date, vote average, and overview) is displayed alongside the movie poster. 

Genre Display Enhancement: Rather than displaying only the first three genres of a movie, we now fetch and display all associated genres.  This has been done by transforming the array of `Genre` objects into an array of genre names, which then join into a single string with commas as separators.

These changes significantly enhance the usability of the app and provide users with a more complete understanding of each movie. 